### PR TITLE
Support for private constructors

### DIFF
--- a/source/Halite.Serialization.JsonNet/HalEmbeddedJsonConverter.cs
+++ b/source/Halite.Serialization.JsonNet/HalEmbeddedJsonConverter.cs
@@ -132,7 +132,7 @@ namespace Halite.Serialization.JsonNet
 
         private static ConstructorInfo SelectConstructor(Type objectType)
         {
-            var constructors = objectType.GetConstructors();
+            var constructors = objectType.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
 
             return SelectAnnotatedJsonConstructor(constructors) ??
                    SelectDefaultConstructor(constructors) ??

--- a/source/Halite.Serialization.JsonNet/HalLinkJsonConverter.cs
+++ b/source/Halite.Serialization.JsonNet/HalLinkJsonConverter.cs
@@ -163,7 +163,7 @@ namespace Halite.Serialization.JsonNet
 
         private static ConstructorInfo SelectSubclassConstructor(Type objectType)
         {
-            var constructors = objectType.GetConstructors();
+            var constructors = objectType.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
 
             return SelectAnnotatedJsonConstructor(constructors) ??
                    SelectDefaultConstructor(constructors) ??

--- a/source/Halite.Serialization.JsonNet/HalResourceJsonConverter.cs
+++ b/source/Halite.Serialization.JsonNet/HalResourceJsonConverter.cs
@@ -161,7 +161,7 @@ namespace Halite.Serialization.JsonNet
 
         private static ConstructorInfo SelectConstructor(Type objectType)
         {
-            var constructors = objectType.GetConstructors();
+            var constructors = objectType.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
 
             return SelectAnnotatedJsonConstructor(constructors) ??
                    SelectDefaultConstructor(constructors) ??

--- a/source/Halite.Tests/DummyResourceWithPrivateConstructor.cs
+++ b/source/Halite.Tests/DummyResourceWithPrivateConstructor.cs
@@ -1,0 +1,21 @@
+﻿using Newtonsoft.Json;
+
+namespace Halite.Tests
+{
+    internal class DummyResourceWithPrivateConstructor : HalResource<DummyLinks>
+    {
+        internal DummyResourceWithPrivateConstructor Create(DummyLinks dummyLinks)
+        {
+
+            var it = new DummyResourceWithPrivateConstructor();
+            it.Links = dummyLinks;
+            return it;
+        }
+
+        [JsonConstructor]
+        private DummyResourceWithPrivateConstructor()
+        {
+
+        }
+    }
+}

--- a/source/Halite.Tests/HalResourceDeserializationTests.cs
+++ b/source/Halite.Tests/HalResourceDeserializationTests.cs
@@ -17,6 +17,14 @@ namespace Halite.Tests
         }
 
         [Fact]
+        public void VerifyDeserializeDummyResrouceWithPrivateConstructor()
+        {
+            const string json = "{\"_links\":{\"this\":{\"href\":\"/this\"},\"that\":{\"href\":\"/that\"},\"self\":{\"href\":\"/lambda\"},\"those\":[{\"href\":\"/quux\"},{\"href\":\"/xuuq\"}]}}";
+            var resource = Deserialize<DummyResourceWithPrivateConstructor>(json);
+            resource.Links.Self.Href.ToString().ShouldBe("/lambda");
+        }
+
+        [Fact]
         public void VerifyDeserializeDummyResourceWithLinksAndNullEmbedded()
         {
             const string json = "{\"_links\":{\"this\":{\"href\":\"/this\"},\"that\":{\"href\":\"/that\"},\"self\":{\"href\":\"/lambda\"},\"those\":[{\"href\":\"/quux\"},{\"href\":\"/xuuq\"}]}}";

--- a/source/Halite.Tests/Halite.Tests.csproj
+++ b/source/Halite.Tests/Halite.Tests.csproj
@@ -43,6 +43,7 @@
     <Compile Include="DummyLinks.cs" />
     <Compile Include="DummyResourceWithLinks.cs" />
     <Compile Include="DummyResourceWithLinksAndEmbedded.cs" />
+    <Compile Include="DummyResourceWithPrivateConstructor.cs" />
     <Compile Include="EmbeddedTurtle.cs" />
     <Compile Include="HalLinkDeserializationTests.cs" />
     <Compile Include="HalLinksDeserializationTests.cs" />


### PR DESCRIPTION
We often use private constructors with [JsonConstructor] attribute. Bindingflags must be configured for these constructors to be picked up by the GetConstructors method.